### PR TITLE
Remove Source Browser badge and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![NuGet version](https://img.shields.io/nuget/v/FakeItEasy.svg?style=flat)](https://www.nuget.org/packages/FakeItEasy)
 [![Build status](https://ci.appveyor.com/api/projects/status/tmxobysgprwpecsb/branch/master?svg=true)](https://ci.appveyor.com/project/FakeItEasy/fakeiteasy/branch/master)
-[![Source Browser](https://img.shields.io/badge/Browse-Source-green.svg)](http://sourcebrowser.io/Browse/FakeItEasy/FakeItEasy)
 
 A .Net dynamic fake library for creating all types of fake objects, mocks, stubs etc.
 


### PR DESCRIPTION
sourcebrowser.io appears to be dead, and has been in this state for a while. No reason to keep the badge.